### PR TITLE
Fix support for SIOCDEVPRIVATE ioctls from 5.15.0 onwards.

### DIFF
--- a/include/osdep_intf.h
+++ b/include/osdep_intf.h
@@ -79,6 +79,11 @@ uint loadparam(_adapter *adapter);
 #ifdef PLATFORM_LINUX
 int rtw_ioctl(struct net_device *dev, struct ifreq *rq, int cmd);
 
+#if ((LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)) && defined(CONFIG_MP_INCLUDED))
+int rtw_siocdevprivate(struct net_device *dev, struct ifreq *ifr,
+                       void __user *data, int cmd);
+#endif
+
 int rtw_init_netdev_name(struct net_device *pnetdev, const char *ifname);
 struct net_device *rtw_init_netdev(_adapter *padapter);
 

--- a/os_dep/linux/ioctl_linux.c
+++ b/os_dep/linux/ioctl_linux.c
@@ -13058,3 +13058,14 @@ int rtw_ioctl(struct net_device *dev, struct ifreq *rq, int cmd)
 
 	return ret;
 }
+
+#if ((LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)) && defined(CONFIG_MP_INCLUDED))
+int rtw_siocdevprivate(struct net_device *dev, struct ifreq *ifr,
+                       void __user *data, int cmd)
+{
+	if (cmd != SIOCDEVPRIVATE)
+		return -EOPNOTSUPP;
+
+	return rtw_ioctl_standard_wext_private(dev, ifr);
+}
+#endif

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -1849,6 +1849,9 @@ static const struct net_device_ops rtw_netdev_ops = {
 	.ndo_set_mac_address = rtw_net_set_mac_address,
 	.ndo_get_stats = rtw_net_get_stats,
 	.ndo_do_ioctl = rtw_ioctl,
+#if ((LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)) && defined(CONFIG_MP_INCLUDED))
+	.ndo_siocdevprivate = rtw_siocdevprivate,
+#endif
 };
 #endif
 
@@ -3347,6 +3350,9 @@ static const struct net_device_ops rtw_netdev_vir_if_ops = {
 	.ndo_set_mac_address = rtw_net_set_mac_address,
 	.ndo_get_stats = rtw_net_get_stats,
 	.ndo_do_ioctl = rtw_ioctl,
+#if ((LINUX_VERSION_CODE >= KERNEL_VERSION(5, 15, 0)) && defined(CONFIG_MP_INCLUDED))
+	.ndo_siocdevprivate = rtw_siocdevprivate,
+#endif
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(2, 6, 35))
 	.ndo_select_queue	= rtw_select_queue,
 #endif


### PR DESCRIPTION
From 5.15.0 onwards, SIOCDEVPRIVATE has been split into a seperate function. https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=b9067f5dc4a07c8e24e01a1b277c6722d91be39e

This patch fixes support for the new SIOCDEVPRIVATE handling.

Notes:
In order to access these commands, CONFIG_MP_INCLUDED must be set to 'y'. They can then be accessed with the correct ioctl.
Example application to do this can be found here:
https://github.com/lfelten/rtl_iw_priv