### PR TITLE
fix: os_dep/osdep_service.c: Add a checking kernel version (>=5.4) fo…

### DIFF
--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -52,8 +52,10 @@ inline int RTW_STATUS_CODE(int error_code)
 }
 #endif
 
+#ifdef ANDROID_GKI_VFS_EXPORT_ONLY
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0))
 	MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
+#endif
 #endif
 
 u32 rtw_atoi(u8 *s)

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -52,6 +52,10 @@ inline int RTW_STATUS_CODE(int error_code)
 }
 #endif
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
+	MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
+#endif
+
 u32 rtw_atoi(u8 *s)
 {
 

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -52,10 +52,14 @@ inline int RTW_STATUS_CODE(int error_code)
 }
 #endif
 
+/* Include namespace when file system namespace errors occur during kernel build.
+ * about 'kernel_read' or 'kernel_write'
+ *
+ * This declaration was created to resolve an error on the Rockchip side
+ * You can modify or add flags in the fs/Makefile.
+ */
 #ifdef ANDROID_GKI_VFS_EXPORT_ONLY
-#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0))
 	MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
-#endif
 #endif
 
 u32 rtw_atoi(u8 *s)

--- a/os_dep/osdep_service.c
+++ b/os_dep/osdep_service.c
@@ -52,7 +52,7 @@ inline int RTW_STATUS_CODE(int error_code)
 }
 #endif
 
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0)
+#if (LINUX_VERSION_CODE >= KERNEL_VERSION(5, 4, 0))
 	MODULE_IMPORT_NS(VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver);
 #endif
 


### PR DESCRIPTION
…r MODULE_IMPORT_NS

[error 1] in Rockchip v20230524 kernel 5.10.y

ERROR: modpost: module 8821cu uses symbol kernel_write from namespace VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver, but does not import it.
ERROR: modpost: module 8821cu uses symbol kernel_read from namespace VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver, but does not import it.
ERROR: modpost: module 8821cu uses symbol filp_open from namespace VFS_internal_I_am_really_a_filesystem_and_am_NOT_a_driver, but does not import it.
make[1]: *** [scripts/Makefile.modpost:168: modules-only.symvers] Error 1
make[1]: *** Deleting file 'modules-only.symvers'
make: *** [Makefile:1524: modules] Error 2
make: *** Waiting for unfinished jobs....

[error 2] build error in kernel 4.19.y

type defaults to 'int' in declaration of 'MODULE_IMPORT_NS' [-Werror=implicit-int] ...