### PR TITLE
Added command to delete the driver folder in /var/lib/dkms/ when the driver is removed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 *.mod.c
 Module.symvers
 modules.order
+.vscode/

--- a/remove-driver.sh
+++ b/remove-driver.sh
@@ -146,6 +146,8 @@ rm -f /etc/modprobe.d/${OPTIONS_FILE}
 echo "Removing source files from /usr/src/${DRV_NAME}-${DRV_VERSION}"
 rm -rf /usr/src/${DRV_NAME}-${DRV_VERSION}
 make clean >/dev/null 2>&1
+echo "Removing driver from the DKMS tree"
+rm -rf /var/lib/dkms/rtl8821cu
 echo "The driver was removed successfully."
 echo "You may now delete the driver directory if desired."
 echo ": ---------------------------"


### PR DESCRIPTION
When the driver is removed using the remove-driver.sh script (mostly after updating the Linux kernel), the driver folder remains in the /var/lib/dkms/ folder, which causes issues to reinstall the driver after kernel updates and even blocks another DKMS software to update. I simply added two lines to remove the driver folder in the designed location, solving this problem.