### PR TITLE
Fixing Makefile to respect out of tree builds as documented at https://docs.kernel.org/kbuild/modules.html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2485,11 +2485,15 @@ ifeq ($(CONFIG_RTL8723B), y)
 $(MODULE_NAME)-$(CONFIG_MP_INCLUDED)+= core/rtw_bt_mp.o
 endif
 
-obj-$(CONFIG_RTL8821CU) := $(MODULE_NAME).o
+# export CONFIG_RTL8821CU=y to build driver in tree
+# else driver will be built out of tree by default
+ifeq ($(CONFIG_RTL8821CU), y)
+	obj-y := $(MODULE_NAME).o
+else
+	obj-m := $(MODULE_NAME).o
+endif
 
 else
-
-export CONFIG_RTL8821CU = m
 
 all: modules
 


### PR DESCRIPTION
Fixing Makefile to respect out of tree builds as documented at https://docs.kernel.org/kbuild/modules.html

This change fixes an empty module target when invoked by `make -C <path_to_kernel_src> M=$PWD` due to missing `export CONFIG_RTL8821CU = m`.

Since kbuild only respects `obj-y := ...` for in-tree and `obj-m := ...` for out of tree builds, it is safe to assume obj-m to be the default as this mimicks existing behavior, still retaining the option to build in-tree if needed.