### PR TITLE
Fix build for kernel 6.16

### DIFF
--- a/include/osdep_service_linux.h
+++ b/include/osdep_service_linux.h
@@ -210,6 +210,10 @@ typedef void	*thread_context;
 typedef void timer_hdl_return;
 typedef void *timer_hdl_context;
 
+#if (LINUX_VERSION_CODE > KERNEL_VERSION(6, 16, 0))
+#define from_timer     timer_container_of
+#endif
+
 #if (LINUX_VERSION_CODE > KERNEL_VERSION(2, 5, 41))
 	typedef struct work_struct _workitem;
 #else


### PR DESCRIPTION
With commit:
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=41cb08555c4164996d67c78b3bf1c658075b75f1 from_timer() has been renamed to timer_container_of() so let's rename according to linux version >= 6.16.