### PR TITLE
add support for Mercusys AC650 (MU6H)

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -140,6 +140,7 @@ static void rtw_dev_shutdown(struct device *dev)
 
 #define USB_VENDER_ID_EDIMAX		0x7392
 #define USB_VENDER_ID_REALTEK		0x0BDA
+#define USB_VENDER_ID_MERCUSYS		0x2C4E
 
 
 /* DID_USB_v916_20130116 */
@@ -271,6 +272,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	/*=== Customer ID ===*/
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_EDIMAX, 0xC811, 0xff, 0xff, 0xff), .driver_info = RTL8821C}, /* 8811CU Edimax */
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_EDIMAX, 0xD811, 0xff, 0xff, 0xff), .driver_info = RTL8821C}, /* 8811CU Edimax */
+	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_MERCUSYS, 0x0105, 0xff, 0xff, 0xff), .driver_info = RTL8821C}, /* 8811CU Mercusys AC650 */
 	{USB_DEVICE_AND_INTERFACE_INFO(0x2001, 0x331d, 0xff, 0xff, 0xff), .driver_info = RTL8821C}, /* D-Link - DWA-171C */
 #endif
 


### PR DESCRIPTION
Adding support for Mercusys AC650 (MU6H).

```sh
$ lsusb
...
Bus 003 Device 007: ID 2c4e:0105 Mercucys INC 802.11ac NIC
...
```

Product page: https://www.mercusys.com/en/product/details/mu6h/