### PR TITLE
Fix hmac_sha256() conflict with linux function

### DIFF
--- a/core/crypto/sha256.c
+++ b/core/crypto/sha256.c
@@ -97,7 +97,7 @@ int hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
  * @mac: Buffer for the hash (32 bytes)
  * Returns: 0 on success, -1 on failure
  */
-int hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
+int rtl_hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
 		size_t data_len, u8 *mac)
 {
 	return hmac_sha256_vector(key, key_len, 1, &data, &data_len, mac);

--- a/core/crypto/sha256.h
+++ b/core/crypto/sha256.h
@@ -13,7 +13,7 @@
 
 int hmac_sha256_vector(const u8 *key, size_t key_len, size_t num_elem,
 		       const u8 *addr[], const size_t *len, u8 *mac);
-int hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
+int rtl_hmac_sha256(const u8 *key, size_t key_len, const u8 *data,
 		size_t data_len, u8 *mac);
 int sha256_prf(const u8 *key, size_t key_len, const char *label,
 	       const u8 *data, size_t data_len, u8 *buf, size_t buf_len);


### PR DESCRIPTION
Prefix local hmac_sha256() with rtl_ resulting into rtl_hmac_sha256().