### PR TITLE
Add cooperative RX diversity mode for dual USB adapters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2445,7 +2445,8 @@ rtk_core :=	core/rtw_cmd.o \
 		core/rtw_mbo.o \
 		core/rtw_rm_util.o \
 		core/efuse/rtw_efuse.o \
-		core/rtw_roch.o
+		core/rtw_roch.o \
+		core/rtw_cooperative_rx.o
 
 ifeq ($(CONFIG_SDIO_HCI), y)
 rtk_core += core/rtw_sdio.o

--- a/core/monitor/rtw_radiotap.c
+++ b/core/monitor/rtw_radiotap.c
@@ -283,16 +283,16 @@ sint rtw_fill_radiotap_hdr(_adapter *padapter, struct rx_pkt_attrib *a, u8 *buf)
 	}
 
 	/* dBm Antenna Signal */
-	rtap_hdr->it_present |= BIT(IEEE80211_RADIOTAP_DBM_ANTSIGNAL);
+	/*rtap_hdr->it_present |= BIT(IEEE80211_RADIOTAP_DBM_ANTSIGNAL);
 	hdr_buf[rt_len] = a->phy_info.recv_signal_power;
-	rt_len += 1;
+	rt_len += 1;*/
 
-#if 1
-	/* dBm Antenna Noise */
-	rtap_hdr->it_present |= BIT(IEEE80211_RADIOTAP_DBM_ANTNOISE);
-	hdr_buf[rt_len] = 0;
-	rt_len += 1;
-#endif
+//#if 0
+  /* dBm Antenna Noise */
+  //rtap_hdr->it_present |= BIT(IEEE80211_RADIOTAP_DBM_ANTNOISE);
+  //hdr_buf[rt_len] = a->phy_info.recv_signal_power;
+  //rt_len += 1;
+//#endif
 #if 1
 	/* Signal Quality, Required Alignment: 2 bytes */
 	rtap_hdr->it_present |= BIT(IEEE80211_RADIOTAP_LOCK_QUALITY);

--- a/core/monitor/rtw_radiotap.c
+++ b/core/monitor/rtw_radiotap.c
@@ -163,7 +163,7 @@ static inline void _rtw_radiotap_fill_flags(struct rx_pkt_attrib *a, u8 *flags)
 
 sint rtw_fill_radiotap_hdr(_adapter *padapter, struct rx_pkt_attrib *a, u8 *buf)
 {
-#define RTAP_HDR_MAX 64
+#define RTAP_HDR_MAX 256
 
 	sint ret = _SUCCESS;
 	struct moinfo *moif = (struct moinfo *)&a->moif;
@@ -199,7 +199,7 @@ sint rtw_fill_radiotap_hdr(_adapter *padapter, struct rx_pkt_attrib *a, u8 *buf)
 	/* each antenna information */
 	rx_cnt = rf_type_to_rf_rx_cnt(pHalData->rf_type);
 #if 0
-	if (rx_cnt > 1) {
+	if (rx_cnt >= 1) {
 		rtap_hdr->it_present |= BIT(IEEE80211_RADIOTAP_RADIOTAP_NAMESPACE) |
 		BIT(IEEE80211_RADIOTAP_EXT);
 
@@ -287,13 +287,13 @@ sint rtw_fill_radiotap_hdr(_adapter *padapter, struct rx_pkt_attrib *a, u8 *buf)
 	hdr_buf[rt_len] = a->phy_info.recv_signal_power;
 	rt_len += 1;
 
-#if 0
+#if 1
 	/* dBm Antenna Noise */
 	rtap_hdr->it_present |= BIT(IEEE80211_RADIOTAP_DBM_ANTNOISE);
 	hdr_buf[rt_len] = 0;
 	rt_len += 1;
 #endif
-#if 0
+#if 1
 	/* Signal Quality, Required Alignment: 2 bytes */
 	rtap_hdr->it_present |= BIT(IEEE80211_RADIOTAP_LOCK_QUALITY);
 	if (!IS_ALIGNED(rt_len, 2))
@@ -303,13 +303,13 @@ sint rtw_fill_radiotap_hdr(_adapter *padapter, struct rx_pkt_attrib *a, u8 *buf)
 
 #endif
 
-#if 0
+#if 1
 	/* Antenna */
 	rtap_hdr->it_present |= BIT(IEEE80211_RADIOTAP_ANTENNA);
 	hdr_buf[rt_len] = 0; /* pHalData->rf_type; */
 	rt_len += 1;
 #endif
-#if 0
+#if 1
 	/* RX flags, Required Alignment: 2 bytes */
 	rtap_hdr->it_present |= BIT(IEEE80211_RADIOTAP_RX_FLAGS);
 	tmp_16bit = 0;
@@ -558,8 +558,8 @@ sint rtw_fill_radiotap_hdr(_adapter *padapter, struct rx_pkt_attrib *a, u8 *buf)
 	}
 
 	/* each antenna information */
-#if 0
-	if (rx_cnt > 1) {
+#if 1
+	if (rx_cnt >= 1) {
 		for (i = 0; i <= rx_cnt; i++) {
 			/* dBm Antenna Signal */
 			hdr_buf[rt_len] = a->phy_info.rx_mimo_signal_strength[i];

--- a/core/monitor/rtw_radiotap.c
+++ b/core/monitor/rtw_radiotap.c
@@ -283,16 +283,16 @@ sint rtw_fill_radiotap_hdr(_adapter *padapter, struct rx_pkt_attrib *a, u8 *buf)
 	}
 
 	/* dBm Antenna Signal */
-	/*rtap_hdr->it_present |= BIT(IEEE80211_RADIOTAP_DBM_ANTSIGNAL);
+	rtap_hdr->it_present |= BIT(IEEE80211_RADIOTAP_DBM_ANTSIGNAL);
 	hdr_buf[rt_len] = a->phy_info.recv_signal_power;
-	rt_len += 1;*/
+	rt_len += 1;
 
-//#if 0
+#if 1
   /* dBm Antenna Noise */
-  //rtap_hdr->it_present |= BIT(IEEE80211_RADIOTAP_DBM_ANTNOISE);
-  //hdr_buf[rt_len] = a->phy_info.recv_signal_power;
-  //rt_len += 1;
-//#endif
+  rtap_hdr->it_present |= BIT(IEEE80211_RADIOTAP_DBM_ANTNOISE);
+  hdr_buf[rt_len] = a->phy_info.recv_signal_power;
+  rt_len += 1;
+#endif
 #if 1
 	/* Signal Quality, Required Alignment: 2 bytes */
 	rtap_hdr->it_present |= BIT(IEEE80211_RADIOTAP_LOCK_QUALITY);

--- a/core/rtw_cooperative_rx.c
+++ b/core/rtw_cooperative_rx.c
@@ -1,0 +1,911 @@
+/******************************************************************************
+ *
+ * Copyright(c) 2024 Realtek Corporation.
+ *
+ * Cooperative RX Diversity Mode — Core Implementation
+ *
+ * Enables a helper USB adapter to contribute received frames to a primary
+ * adapter's RX path, improving robustness under fading/interference.
+ *
+ * Architecture:
+ *   - Primary adapter operates normally in STA mode
+ *   - Helper adapter(s) are slaved to the same channel/BSSID
+ *   - Helper RX frames are validated and injected into primary's
+ *     AMPDU reorder window, which provides natural duplicate suppression
+ *   - One coherent RX stream is delivered to the network stack
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ *****************************************************************************/
+
+#define pr_fmt(fmt) "rtw_coop_rx: " fmt
+
+#include <drv_types.h>
+#include <rtw_recv.h>
+#include <rtw_cooperative_rx.h>
+
+#ifdef CONFIG_DEBUG_FS
+#include <linux/debugfs.h>
+#include <linux/seq_file.h>
+#endif
+
+/* Module parameter — 0=disabled (default), 1=enabled */
+int rtw_cooperative_rx = 0;
+
+/* Global cooperative group singleton */
+struct cooperative_rx_group *rtw_coop_rx_group = NULL;
+
+/*
+ * ============================================================
+ * Lifecycle Management
+ * ============================================================
+ */
+
+int rtw_coop_rx_init(void)
+{
+	struct cooperative_rx_group *grp;
+
+	if (!rtw_coop_rx_enabled())
+		return 0;
+
+	grp = rtw_zmalloc(sizeof(*grp));
+	if (!grp) {
+		RTW_ERR("%s: failed to allocate cooperative group\n", __func__);
+		return -ENOMEM;
+	}
+
+	spin_lock_init(&grp->lock);
+	grp->state = COOP_STATE_IDLE;
+	grp->primary = NULL;
+	grp->num_helpers = 0;
+	memset(&grp->stats, 0, sizeof(grp->stats));
+
+	/* Publish the group pointer */
+	smp_wmb();
+	WRITE_ONCE(rtw_coop_rx_group, grp);
+
+	RTW_INFO("%s: cooperative RX group initialized\n", __func__);
+
+#ifdef CONFIG_DEBUG_FS
+	rtw_coop_rx_debugfs_init();
+#endif
+
+	return 0;
+}
+
+void rtw_coop_rx_deinit(void)
+{
+	struct cooperative_rx_group *grp;
+	unsigned long flags;
+
+	grp = READ_ONCE(rtw_coop_rx_group);
+	if (!grp)
+		return;
+
+#ifdef CONFIG_DEBUG_FS
+	rtw_coop_rx_debugfs_deinit();
+#endif
+
+	spin_lock_irqsave(&grp->lock, flags);
+	grp->state = COOP_STATE_DISABLED;
+	grp->primary = NULL;
+	grp->num_helpers = 0;
+	spin_unlock_irqrestore(&grp->lock, flags);
+
+	/* Ensure no readers are in the hot path */
+	synchronize_rcu();
+
+	WRITE_ONCE(rtw_coop_rx_group, NULL);
+	rtw_mfree((u8 *)grp, sizeof(*grp));
+
+	RTW_INFO("%s: cooperative RX group destroyed\n", __func__);
+}
+
+/*
+ * ============================================================
+ * Adapter Pairing
+ * ============================================================
+ */
+
+int rtw_coop_rx_set_primary(_adapter *adapter)
+{
+	struct cooperative_rx_group *grp;
+	unsigned long flags;
+
+	if (!rtw_coop_rx_enabled())
+		return -ENODEV;
+
+	grp = READ_ONCE(rtw_coop_rx_group);
+	if (!grp)
+		return -ENODEV;
+
+	spin_lock_irqsave(&grp->lock, flags);
+
+	if (grp->primary && grp->primary != adapter) {
+		RTW_WARN("%s: primary already set to different adapter\n",
+			 __func__);
+		spin_unlock_irqrestore(&grp->lock, flags);
+		return -EBUSY;
+	}
+
+	grp->primary = adapter;
+	grp->primary_dvobj = adapter_to_dvobj(adapter);
+
+	if (grp->state == COOP_STATE_IDLE || grp->state == COOP_STATE_DISABLED)
+		grp->state = COOP_STATE_IDLE;
+
+	spin_unlock_irqrestore(&grp->lock, flags);
+
+	RTW_INFO("%s: primary adapter set (iface_id=%d, mac="MAC_FMT")\n",
+		 __func__, adapter->iface_id,
+		 MAC_ARG(adapter_mac_addr(adapter)));
+	return 0;
+}
+
+int rtw_coop_rx_add_helper(_adapter *adapter)
+{
+	struct cooperative_rx_group *grp;
+	unsigned long flags;
+	int i;
+
+	if (!rtw_coop_rx_enabled())
+		return -ENODEV;
+
+	grp = READ_ONCE(rtw_coop_rx_group);
+	if (!grp)
+		return -ENODEV;
+
+	spin_lock_irqsave(&grp->lock, flags);
+
+	if (!grp->primary) {
+		RTW_WARN("%s: no primary adapter set\n", __func__);
+		spin_unlock_irqrestore(&grp->lock, flags);
+		return -EINVAL;
+	}
+
+	if (grp->num_helpers >= COOP_MAX_HELPERS) {
+		RTW_WARN("%s: max helpers reached (%d)\n",
+			 __func__, COOP_MAX_HELPERS);
+		spin_unlock_irqrestore(&grp->lock, flags);
+		return -ENOSPC;
+	}
+
+	/* Check for duplicate */
+	for (i = 0; i < grp->num_helpers; i++) {
+		if (grp->helpers[i] == adapter) {
+			spin_unlock_irqrestore(&grp->lock, flags);
+			return 0; /* already added */
+		}
+	}
+
+	grp->helpers[grp->num_helpers] = adapter;
+	grp->helper_dvobjs[grp->num_helpers] = adapter_to_dvobj(adapter);
+	grp->num_helpers++;
+
+	if (grp->state == COOP_STATE_IDLE)
+		grp->state = COOP_STATE_BINDING;
+
+	atomic_inc(&grp->stats.pair_events);
+	spin_unlock_irqrestore(&grp->lock, flags);
+
+	RTW_INFO("%s: helper adapter added (iface_id=%d, mac="MAC_FMT
+		 ", total_helpers=%d)\n",
+		 __func__, adapter->iface_id,
+		 MAC_ARG(adapter_mac_addr(adapter)),
+		 grp->num_helpers);
+	return 0;
+}
+
+int rtw_coop_rx_remove_helper(_adapter *adapter)
+{
+	struct cooperative_rx_group *grp;
+	unsigned long flags;
+	int i, found = 0;
+
+	grp = READ_ONCE(rtw_coop_rx_group);
+	if (!grp)
+		return -ENODEV;
+
+	spin_lock_irqsave(&grp->lock, flags);
+
+	for (i = 0; i < grp->num_helpers; i++) {
+		if (grp->helpers[i] == adapter) {
+			found = 1;
+			/* Shift remaining helpers down */
+			for (; i < grp->num_helpers - 1; i++) {
+				grp->helpers[i] = grp->helpers[i + 1];
+				grp->helper_dvobjs[i] = grp->helper_dvobjs[i + 1];
+			}
+			grp->helpers[grp->num_helpers - 1] = NULL;
+			grp->helper_dvobjs[grp->num_helpers - 1] = NULL;
+			grp->num_helpers--;
+			break;
+		}
+	}
+
+	if (found) {
+		atomic_inc(&grp->stats.unpair_events);
+		if (grp->num_helpers == 0 && grp->state == COOP_STATE_ACTIVE) {
+			grp->state = COOP_STATE_IDLE;
+			atomic_inc(&grp->stats.fallback_events);
+			RTW_INFO("%s: last helper removed, falling back to "
+				 "primary-only mode\n", __func__);
+		}
+	}
+
+	spin_unlock_irqrestore(&grp->lock, flags);
+
+	/* Wait for any in-flight helper RX processing */
+	if (found)
+		synchronize_rcu();
+
+	return found ? 0 : -ENOENT;
+}
+
+/*
+ * Called when any adapter is being removed (USB disconnect, driver unload).
+ * Safely removes it from the cooperative group regardless of role.
+ */
+void rtw_coop_rx_remove_adapter(_adapter *adapter)
+{
+	struct cooperative_rx_group *grp;
+	unsigned long flags;
+
+	if (!rtw_coop_rx_enabled())
+		return;
+
+	grp = READ_ONCE(rtw_coop_rx_group);
+	if (!grp)
+		return;
+
+	/* Try removing as helper first */
+	rtw_coop_rx_remove_helper(adapter);
+
+	/* Check if it's the primary */
+	spin_lock_irqsave(&grp->lock, flags);
+	if (grp->primary == adapter) {
+		RTW_INFO("%s: primary adapter removed, tearing down "
+			 "cooperative group\n", __func__);
+		grp->state = COOP_STATE_TEARDOWN;
+		grp->primary = NULL;
+		grp->primary_dvobj = NULL;
+		grp->num_helpers = 0;
+		memset(grp->helpers, 0, sizeof(grp->helpers));
+		memset(grp->helper_dvobjs, 0, sizeof(grp->helper_dvobjs));
+		grp->state = COOP_STATE_IDLE;
+		atomic_inc(&grp->stats.fallback_events);
+	}
+	spin_unlock_irqrestore(&grp->lock, flags);
+}
+
+/*
+ * Bind cooperative session to primary's current BSS.
+ * Called after primary successfully associates.
+ */
+int rtw_coop_rx_bind_session(_adapter *primary)
+{
+	struct cooperative_rx_group *grp;
+	struct mlme_priv *pmlmepriv;
+	struct wlan_network *cur_network;
+	unsigned long flags;
+
+	if (!rtw_coop_rx_enabled())
+		return -ENODEV;
+
+	grp = READ_ONCE(rtw_coop_rx_group);
+	if (!grp || grp->primary != primary)
+		return -ENODEV;
+
+	pmlmepriv = &primary->mlmepriv;
+	cur_network = &pmlmepriv->cur_network;
+
+	if (!check_fwstate(pmlmepriv, WIFI_STATION_STATE) ||
+	    !check_fwstate(pmlmepriv, WIFI_ASOC_STATE)) {
+		RTW_WARN("%s: primary not associated in STA mode\n", __func__);
+		return -ENOTCONN;
+	}
+
+	spin_lock_irqsave(&grp->lock, flags);
+
+	/* Capture BSS context */
+	_rtw_memcpy(grp->bound_bssid,
+		     cur_network->network.MacAddress, ETH_ALEN);
+	_rtw_memcpy(grp->bound_ap_mac,
+		     cur_network->network.MacAddress, ETH_ALEN);
+	grp->bound_channel = primary->mlmeextpriv.cur_channel;
+	grp->bound_bw = primary->mlmeextpriv.cur_bwmode;
+
+	/* Reset non-QoS dedup cache */
+	memset(&grp->nonqos_cache, 0, sizeof(grp->nonqos_cache));
+
+	if (grp->num_helpers > 0)
+		grp->state = COOP_STATE_ACTIVE;
+
+	spin_unlock_irqrestore(&grp->lock, flags);
+
+	RTW_INFO("%s: session bound to BSSID="MAC_FMT" ch=%u bw=%u "
+		 "(helpers=%d, state=%s)\n",
+		 __func__, MAC_ARG(grp->bound_bssid),
+		 grp->bound_channel, grp->bound_bw,
+		 grp->num_helpers,
+		 grp->state == COOP_STATE_ACTIVE ? "ACTIVE" : "BINDING");
+	return 0;
+}
+
+void rtw_coop_rx_unbind_session(void)
+{
+	struct cooperative_rx_group *grp;
+	unsigned long flags;
+
+	grp = READ_ONCE(rtw_coop_rx_group);
+	if (!grp)
+		return;
+
+	spin_lock_irqsave(&grp->lock, flags);
+	if (grp->state == COOP_STATE_ACTIVE ||
+	    grp->state == COOP_STATE_BINDING) {
+		grp->state = grp->primary ? COOP_STATE_IDLE : COOP_STATE_DISABLED;
+		memset(grp->bound_bssid, 0, ETH_ALEN);
+		memset(grp->bound_ap_mac, 0, ETH_ALEN);
+		grp->bound_channel = 0;
+		RTW_INFO("%s: session unbound\n", __func__);
+	}
+	spin_unlock_irqrestore(&grp->lock, flags);
+}
+
+/*
+ * ============================================================
+ * Non-QoS Duplicate Detection Cache
+ * ============================================================
+ *
+ * For AMPDU/QoS traffic, the reorder window provides natural dedup.
+ * For non-QoS traffic, we maintain a small ring buffer of recently
+ * seen sequence numbers.
+ */
+
+static bool coop_nonqos_is_dup(struct cooperative_rx_group *grp, u16 seq_num)
+{
+	struct coop_nonqos_seq_cache *cache = &grp->nonqos_cache;
+	int i;
+
+	for (i = 0; i < COOP_NONQOS_SEQ_CACHE_SZ; i++) {
+		if (cache->seqs[i] == seq_num)
+			return true;
+	}
+
+	/* Not a dup — record it */
+	cache->seqs[cache->idx] = seq_num;
+	cache->idx = (cache->idx + 1) % COOP_NONQOS_SEQ_CACHE_SZ;
+	return false;
+}
+
+/*
+ * ============================================================
+ * Helper RX Hot Path — Frame Injection
+ * ============================================================
+ *
+ * This is the critical function called from the helper adapter's
+ * RX tasklet path. It takes a parsed recv_frame from the helper,
+ * validates it, and injects it into the primary adapter's RX
+ * processing.
+ *
+ * The key insight is that the AMPDU reorder window
+ * (recv_indicatepkt_reorder → enqueue_reorder_recvframe) provides
+ * natural duplicate suppression: inserting a frame with a sequence
+ * number that already has a slot occupied will simply be discarded.
+ *
+ * For non-QoS traffic, we use the nonqos_seq_cache above.
+ */
+int rtw_coop_rx_submit_helper_frame(union recv_frame *precvframe,
+				    _adapter *helper_adapter)
+{
+	struct cooperative_rx_group *grp;
+	struct rx_pkt_attrib *pattrib;
+	_adapter *primary;
+	struct sta_priv *pstapriv;
+	struct sta_info *psta;
+	int ret = _FAIL;
+
+	rcu_read_lock();
+
+	grp = READ_ONCE(rtw_coop_rx_group);
+	if (!grp || grp->state != COOP_STATE_ACTIVE) {
+		rcu_read_unlock();
+		return _FAIL;
+	}
+
+	primary = grp->primary;
+	if (!primary || rtw_is_drv_stopped(primary)) {
+		rcu_read_unlock();
+		return _FAIL;
+	}
+
+	pattrib = &precvframe->u.hdr.attrib;
+
+	atomic_inc(&grp->stats.helper_rx_candidates);
+
+	/* Validate: frame must be from our bound BSSID */
+	if (_rtw_memcmp(pattrib->bssid, grp->bound_bssid, ETH_ALEN) == _FALSE) {
+		atomic_inc(&grp->stats.helper_rx_foreign);
+		rcu_read_unlock();
+		return _FAIL;
+	}
+
+	/* Validate: TA must match bound AP */
+	if (_rtw_memcmp(pattrib->ta, grp->bound_ap_mac, ETH_ALEN) == _FALSE) {
+		atomic_inc(&grp->stats.helper_rx_foreign);
+		rcu_read_unlock();
+		return _FAIL;
+	}
+
+	/* Validate: RA must match primary's MAC (unicast) or be broadcast */
+	if (!IS_MCAST(pattrib->ra) &&
+	    _rtw_memcmp(pattrib->ra, adapter_mac_addr(primary),
+			ETH_ALEN) == _FALSE) {
+		atomic_inc(&grp->stats.helper_rx_foreign);
+		rcu_read_unlock();
+		return _FAIL;
+	}
+
+	/* CRC/ICV errors are useless */
+	if (pattrib->crc_err || pattrib->icv_err) {
+		atomic_inc(&grp->stats.helper_rx_crypto_err);
+		rcu_read_unlock();
+		return _FAIL;
+	}
+
+	/*
+	 * Look up the sta_info on the PRIMARY adapter — this is the
+	 * station context with the reorder windows and crypto state.
+	 */
+	pstapriv = &primary->stapriv;
+	psta = rtw_get_stainfo(pstapriv, pattrib->ta);
+	if (!psta) {
+		atomic_inc(&grp->stats.helper_rx_no_sta);
+		rcu_read_unlock();
+		return _FAIL;
+	}
+
+	/*
+	 * Re-associate the frame with the PRIMARY adapter context.
+	 * This is the key step — the frame now carries the primary's
+	 * adapter pointer and sta_info.
+	 */
+	precvframe->u.hdr.adapter = primary;
+	precvframe->u.hdr.psta = psta;
+
+	/*
+	 * Handle QoS (AMPDU) vs non-QoS differently.
+	 */
+	if (pattrib->qos) {
+		u8 tid = pattrib->priority;
+
+		if (tid > 15) {
+			rcu_read_unlock();
+			return _FAIL;
+		}
+
+		precvframe->u.hdr.preorder_ctrl =
+			&psta->recvreorder_ctrl[tid];
+
+		/*
+		 * Check if this sequence number is before the reorder
+		 * window start — if so, it's too late to be useful.
+		 */
+		if (psta->recvreorder_ctrl[tid].enable) {
+			u16 indicate_seq =
+				psta->recvreorder_ctrl[tid].indicate_seq;
+			if (indicate_seq != 0xFFFF &&
+			    SN_LESS(pattrib->seq_num, indicate_seq)) {
+				atomic_inc(&grp->stats.helper_rx_late);
+				rcu_read_unlock();
+				return _FAIL;
+			}
+		}
+
+		/*
+		 * Attempt decryption if needed.
+		 * If HW already decrypted on the helper (bdecrypted=1),
+		 * we can skip this. Otherwise, attempt SW decrypt using
+		 * primary's security context.
+		 */
+		if (pattrib->encrypt && !pattrib->bdecrypted) {
+			struct security_priv *psec = &primary->securitypriv;
+
+			/*
+			 * For the MVP, skip SW decryption of helper frames.
+			 * HW decrypt should work since both adapters can be
+			 * configured with the same keys.
+			 * If HW didn't decrypt, drop the frame.
+			 */
+			if (psec->dot11PrivacyAlgrthm != _NO_PRIVACY_) {
+				atomic_inc(&grp->stats.helper_rx_crypto_err);
+				rcu_read_unlock();
+				return _FAIL;
+			}
+		}
+
+		/*
+		 * Now inject into the primary's reorder path.
+		 * recv_indicatepkt_reorder() will handle:
+		 *   - sequence window check (drops if too old)
+		 *   - in-order insertion (natural dedup if slot taken)
+		 *   - delivery of consecutive frames
+		 *
+		 * We call this with the primary's context, so locking
+		 * and state are consistent with the primary's own RX.
+		 */
+		ret = recv_indicatepkt_reorder(primary, precvframe);
+		if (ret == RTW_RX_HANDLED || ret == _SUCCESS) {
+			atomic_inc(&grp->stats.helper_rx_accepted);
+			ret = RTW_RX_HANDLED;
+		} else {
+			atomic_inc(&grp->stats.helper_rx_dup_dropped);
+		}
+
+	} else {
+		/*
+		 * Non-QoS frame — check our dedup cache.
+		 * Note: we must hold the group lock briefly for the cache.
+		 */
+		unsigned long flags;
+		bool is_dup;
+
+		spin_lock_irqsave(&grp->lock, flags);
+		is_dup = coop_nonqos_is_dup(grp, pattrib->seq_num);
+		spin_unlock_irqrestore(&grp->lock, flags);
+
+		if (is_dup) {
+			atomic_inc(&grp->stats.helper_rx_dup_dropped);
+			rcu_read_unlock();
+			return _FAIL;
+		}
+
+		/*
+		 * For non-QoS, skip encrypted frames from helper
+		 * (same reasoning as above — rely on HW decrypt).
+		 */
+		if (pattrib->encrypt && !pattrib->bdecrypted) {
+			atomic_inc(&grp->stats.helper_rx_crypto_err);
+			rcu_read_unlock();
+			return _FAIL;
+		}
+
+		/*
+		 * Process as a normal MPDU through the primary path.
+		 * This handles wlanhdr_to_ethhdr conversion and
+		 * delivery to the network stack.
+		 */
+		recv_process_mpdu(primary, precvframe);
+		atomic_inc(&grp->stats.helper_rx_accepted);
+		ret = RTW_RX_HANDLED;
+	}
+
+	rcu_read_unlock();
+	return ret;
+}
+
+/*
+ * ============================================================
+ * sysfs Interface
+ * ============================================================
+ *
+ * Provides /sys/class/net/wlanX/coop_rx/ directory with:
+ *   enabled    - read/write 0/1
+ *   role       - read: "primary", "helper", "none"
+ *   stats      - read: statistics counters
+ *   pair       - write: interface name to pair as helper
+ *   unpair     - write: interface name to unpair
+ *   bind       - write: 1 to bind session (after association)
+ */
+
+static ssize_t coop_rx_show_enabled(struct device *dev,
+				    struct device_attribute *attr, char *buf)
+{
+	struct cooperative_rx_group *grp = READ_ONCE(rtw_coop_rx_group);
+
+	return scnprintf(buf, PAGE_SIZE, "%d\n",
+			 grp ? (grp->state >= COOP_STATE_IDLE ? 1 : 0) : 0);
+}
+
+static ssize_t coop_rx_store_enabled(struct device *dev,
+				     struct device_attribute *attr,
+				     const char *buf, size_t count)
+{
+	int val;
+
+	if (kstrtoint(buf, 10, &val))
+		return -EINVAL;
+
+	if (val == 0 && rtw_coop_rx_group) {
+		rtw_coop_rx_unbind_session();
+		RTW_INFO("coop_rx: disabled via sysfs\n");
+	}
+
+	return count;
+}
+
+static ssize_t coop_rx_show_role(struct device *dev,
+				 struct device_attribute *attr, char *buf)
+{
+	struct net_device *ndev = to_net_dev(dev);
+	_adapter *adapter = rtw_netdev_priv(ndev);
+	struct cooperative_rx_group *grp = READ_ONCE(rtw_coop_rx_group);
+	const char *role = "none";
+
+	if (grp) {
+		if (grp->primary == adapter)
+			role = "primary";
+		else if (rtw_coop_rx_is_helper(adapter))
+			role = "helper";
+	}
+
+	return scnprintf(buf, PAGE_SIZE, "%s\n", role);
+}
+
+static ssize_t coop_rx_show_stats(struct device *dev,
+				  struct device_attribute *attr, char *buf)
+{
+	struct cooperative_rx_group *grp = READ_ONCE(rtw_coop_rx_group);
+	int len = 0;
+
+	if (!grp)
+		return scnprintf(buf, PAGE_SIZE, "disabled\n");
+
+	len += scnprintf(buf + len, PAGE_SIZE - len,
+		"state: %d\n"
+		"num_helpers: %d\n"
+		"bound_bssid: "MAC_FMT"\n"
+		"bound_channel: %u\n"
+		"helper_rx_candidates: %d\n"
+		"helper_rx_accepted: %d\n"
+		"helper_rx_dup_dropped: %d\n"
+		"helper_rx_foreign: %d\n"
+		"helper_rx_crypto_err: %d\n"
+		"helper_rx_late: %d\n"
+		"helper_rx_no_sta: %d\n"
+		"fallback_events: %d\n"
+		"pair_events: %d\n"
+		"unpair_events: %d\n",
+		grp->state,
+		grp->num_helpers,
+		MAC_ARG(grp->bound_bssid),
+		grp->bound_channel,
+		atomic_read(&grp->stats.helper_rx_candidates),
+		atomic_read(&grp->stats.helper_rx_accepted),
+		atomic_read(&grp->stats.helper_rx_dup_dropped),
+		atomic_read(&grp->stats.helper_rx_foreign),
+		atomic_read(&grp->stats.helper_rx_crypto_err),
+		atomic_read(&grp->stats.helper_rx_late),
+		atomic_read(&grp->stats.helper_rx_no_sta),
+		atomic_read(&grp->stats.fallback_events),
+		atomic_read(&grp->stats.pair_events),
+		atomic_read(&grp->stats.unpair_events));
+
+	return len;
+}
+
+static ssize_t coop_rx_store_pair(struct device *dev,
+				  struct device_attribute *attr,
+				  const char *buf, size_t count)
+{
+	struct net_device *ndev = to_net_dev(dev);
+	_adapter *adapter = rtw_netdev_priv(ndev);
+	struct net_device *helper_ndev;
+	_adapter *helper_adapter;
+	char ifname[IFNAMSIZ];
+	int ret;
+
+	if (sscanf(buf, "%15s", ifname) != 1)
+		return -EINVAL;
+
+	/* First, ensure this adapter is set as primary */
+	ret = rtw_coop_rx_set_primary(adapter);
+	if (ret)
+		return ret;
+
+	/* Find the helper interface by name */
+	helper_ndev = dev_get_by_name(&init_net, ifname);
+	if (!helper_ndev) {
+		RTW_WARN("coop_rx: helper interface '%s' not found\n", ifname);
+		return -ENODEV;
+	}
+
+	helper_adapter = rtw_netdev_priv(helper_ndev);
+	if (!helper_adapter) {
+		dev_put(helper_ndev);
+		return -EINVAL;
+	}
+
+	ret = rtw_coop_rx_add_helper(helper_adapter);
+	dev_put(helper_ndev);
+
+	if (ret)
+		return ret;
+
+	return count;
+}
+
+static ssize_t coop_rx_store_unpair(struct device *dev,
+				    struct device_attribute *attr,
+				    const char *buf, size_t count)
+{
+	struct net_device *helper_ndev;
+	_adapter *helper_adapter;
+	char ifname[IFNAMSIZ];
+	int ret;
+
+	if (sscanf(buf, "%15s", ifname) != 1)
+		return -EINVAL;
+
+	helper_ndev = dev_get_by_name(&init_net, ifname);
+	if (!helper_ndev)
+		return -ENODEV;
+
+	helper_adapter = rtw_netdev_priv(helper_ndev);
+	ret = rtw_coop_rx_remove_helper(helper_adapter);
+	dev_put(helper_ndev);
+
+	return ret ? ret : count;
+}
+
+static ssize_t coop_rx_store_bind(struct device *dev,
+				  struct device_attribute *attr,
+				  const char *buf, size_t count)
+{
+	struct net_device *ndev = to_net_dev(dev);
+	_adapter *adapter = rtw_netdev_priv(ndev);
+	int val, ret;
+
+	if (kstrtoint(buf, 10, &val))
+		return -EINVAL;
+
+	if (val == 1) {
+		ret = rtw_coop_rx_bind_session(adapter);
+		if (ret)
+			return ret;
+	} else {
+		rtw_coop_rx_unbind_session();
+	}
+
+	return count;
+}
+
+static DEVICE_ATTR(coop_rx_enabled, 0644,
+		   coop_rx_show_enabled, coop_rx_store_enabled);
+static DEVICE_ATTR(coop_rx_role, 0444, coop_rx_show_role, NULL);
+static DEVICE_ATTR(coop_rx_stats, 0444, coop_rx_show_stats, NULL);
+static DEVICE_ATTR(coop_rx_pair, 0200, NULL, coop_rx_store_pair);
+static DEVICE_ATTR(coop_rx_unpair, 0200, NULL, coop_rx_store_unpair);
+static DEVICE_ATTR(coop_rx_bind, 0200, NULL, coop_rx_store_bind);
+
+static struct attribute *coop_rx_attrs[] = {
+	&dev_attr_coop_rx_enabled.attr,
+	&dev_attr_coop_rx_role.attr,
+	&dev_attr_coop_rx_stats.attr,
+	&dev_attr_coop_rx_pair.attr,
+	&dev_attr_coop_rx_unpair.attr,
+	&dev_attr_coop_rx_bind.attr,
+	NULL,
+};
+
+static const struct attribute_group coop_rx_attr_group = {
+	.name = "coop_rx",
+	.attrs = coop_rx_attrs,
+};
+
+int rtw_coop_rx_sysfs_init(struct net_device *ndev)
+{
+	if (!rtw_coop_rx_enabled())
+		return 0;
+	return sysfs_create_group(&ndev->dev.kobj, &coop_rx_attr_group);
+}
+
+void rtw_coop_rx_sysfs_deinit(struct net_device *ndev)
+{
+	if (!rtw_coop_rx_enabled())
+		return;
+	sysfs_remove_group(&ndev->dev.kobj, &coop_rx_attr_group);
+}
+
+/*
+ * ============================================================
+ * debugfs Interface
+ * ============================================================
+ */
+
+#ifdef CONFIG_DEBUG_FS
+
+static struct dentry *coop_debugfs_dir;
+
+static int coop_debugfs_stats_show(struct seq_file *s, void *data)
+{
+	struct cooperative_rx_group *grp = READ_ONCE(rtw_coop_rx_group);
+
+	if (!grp) {
+		seq_puts(s, "cooperative RX: not initialized\n");
+		return 0;
+	}
+
+	seq_printf(s, "=== Cooperative RX Diversity Stats ===\n");
+	seq_printf(s, "state:                 %d (%s)\n", grp->state,
+		   grp->state == COOP_STATE_DISABLED ? "DISABLED" :
+		   grp->state == COOP_STATE_IDLE ? "IDLE" :
+		   grp->state == COOP_STATE_BINDING ? "BINDING" :
+		   grp->state == COOP_STATE_ACTIVE ? "ACTIVE" :
+		   grp->state == COOP_STATE_TEARDOWN ? "TEARDOWN" : "?");
+	seq_printf(s, "primary:               %s\n",
+		   grp->primary ? "yes" : "no");
+	seq_printf(s, "num_helpers:           %d\n", grp->num_helpers);
+	seq_printf(s, "bound_bssid:           "MAC_FMT"\n",
+		   MAC_ARG(grp->bound_bssid));
+	seq_printf(s, "bound_channel:         %u\n", grp->bound_channel);
+	seq_printf(s, "bound_bw:              %u\n", grp->bound_bw);
+	seq_printf(s, "\n--- Counters ---\n");
+	seq_printf(s, "helper_rx_candidates:  %d\n",
+		   atomic_read(&grp->stats.helper_rx_candidates));
+	seq_printf(s, "helper_rx_accepted:    %d\n",
+		   atomic_read(&grp->stats.helper_rx_accepted));
+	seq_printf(s, "helper_rx_dup_dropped: %d\n",
+		   atomic_read(&grp->stats.helper_rx_dup_dropped));
+	seq_printf(s, "helper_rx_foreign:     %d\n",
+		   atomic_read(&grp->stats.helper_rx_foreign));
+	seq_printf(s, "helper_rx_crypto_err:  %d\n",
+		   atomic_read(&grp->stats.helper_rx_crypto_err));
+	seq_printf(s, "helper_rx_late:        %d\n",
+		   atomic_read(&grp->stats.helper_rx_late));
+	seq_printf(s, "helper_rx_no_sta:      %d\n",
+		   atomic_read(&grp->stats.helper_rx_no_sta));
+	seq_printf(s, "fallback_events:       %d\n",
+		   atomic_read(&grp->stats.fallback_events));
+	seq_printf(s, "pair_events:           %d\n",
+		   atomic_read(&grp->stats.pair_events));
+	seq_printf(s, "unpair_events:         %d\n",
+		   atomic_read(&grp->stats.unpair_events));
+
+	return 0;
+}
+
+static int coop_debugfs_stats_open(struct inode *inode, struct file *file)
+{
+	return single_open(file, coop_debugfs_stats_show, inode->i_private);
+}
+
+static const struct file_operations coop_debugfs_stats_fops = {
+	.open = coop_debugfs_stats_open,
+	.read = seq_read,
+	.llseek = seq_lseek,
+	.release = single_release,
+};
+
+int rtw_coop_rx_debugfs_init(void)
+{
+	coop_debugfs_dir = debugfs_create_dir("rtw_coop_rx", NULL);
+	if (IS_ERR_OR_NULL(coop_debugfs_dir)) {
+		RTW_WARN("coop_rx: failed to create debugfs directory\n");
+		coop_debugfs_dir = NULL;
+		return -ENOMEM;
+	}
+
+	debugfs_create_file("stats", 0444, coop_debugfs_dir,
+			    NULL, &coop_debugfs_stats_fops);
+
+	return 0;
+}
+
+void rtw_coop_rx_debugfs_deinit(void)
+{
+	if (coop_debugfs_dir) {
+		debugfs_remove_recursive(coop_debugfs_dir);
+		coop_debugfs_dir = NULL;
+	}
+}
+
+#else /* !CONFIG_DEBUG_FS */
+
+int rtw_coop_rx_debugfs_init(void) { return 0; }
+void rtw_coop_rx_debugfs_deinit(void) { }
+
+#endif /* CONFIG_DEBUG_FS */

--- a/core/rtw_recv.c
+++ b/core/rtw_recv.c
@@ -16,6 +16,7 @@
 
 #include <drv_types.h>
 #include <hal_data.h>
+#include <rtw_cooperative_rx.h>
 
 #ifdef CONFIG_NEW_SIGNAL_STAT_PROCESS
 static void rtw_signal_stat_timer_hdl(void *ctx);
@@ -3244,7 +3245,7 @@ move_to_next:
 	return ret;
 }
 
-static int recv_process_mpdu(_adapter *padapter, union recv_frame *prframe)
+int recv_process_mpdu(_adapter *padapter, union recv_frame *prframe)
 {
 	_queue *pfree_recv_queue = &padapter->recvpriv.free_recv_queue;
 	struct rx_pkt_attrib *pattrib = &prframe->u.hdr.attrib;
@@ -3618,7 +3619,7 @@ static int recv_indicatepkts_in_order(_adapter *padapter, struct recv_reorder_ct
 
 }
 
-static int recv_indicatepkt_reorder(_adapter *padapter, union recv_frame *prframe)
+int recv_indicatepkt_reorder(_adapter *padapter, union recv_frame *prframe)
 {
 	_irqL irql;
 	struct rx_pkt_attrib *pattrib = &prframe->u.hdr.attrib;
@@ -4769,6 +4770,91 @@ s32 pre_recv_entry(union recv_frame *precvframe, u8 *pphy_status)
 	if (MLME_IS_MONITOR(primary_padapter))
 		goto query_phy_status;
 #endif
+
+	/*
+	 * Cooperative RX: if this adapter is a helper, redirect
+	 * data frames to the cooperative merge path instead of
+	 * normal processing. The merge path validates the frame
+	 * and injects it into the primary adapter's reorder window.
+	 */
+	if (unlikely(rtw_coop_rx_is_helper(primary_padapter))) {
+		u8 frame_type = GetFrameType(pbuf);
+
+		if (frame_type == WIFI_DATA_TYPE) {
+			struct rx_pkt_attrib *pattrib =
+				&precvframe->u.hdr.attrib;
+			u8 to_fr_ds;
+
+			/* Query PHY status first for RSSI info */
+			if (pphy_status)
+				rx_query_phy_status(precvframe, pphy_status);
+
+			/*
+			 * Parse 802.11 header fields needed for merge.
+			 * Address layout depends on To DS / From DS bits.
+			 */
+			to_fr_ds = get_tofr_ds(pbuf);
+			pattrib->to_fr_ds = to_fr_ds;
+			pattrib->seq_num = GetSequence(pbuf);
+			pattrib->frag_num = GetFragNum(pbuf);
+			pattrib->privacy = GetPrivacy(pbuf);
+
+			switch (to_fr_ds) {
+			case 2: /* From DS=1, To DS=0: AP→STA */
+				_rtw_memcpy(pattrib->ra, GetAddr1Ptr(pbuf),
+					    ETH_ALEN);
+				_rtw_memcpy(pattrib->ta, get_addr2_ptr(pbuf),
+					    ETH_ALEN);
+				_rtw_memcpy(pattrib->bssid,
+					    get_addr2_ptr(pbuf), ETH_ALEN);
+				break;
+			case 1: /* From DS=0, To DS=1: STA→AP */
+				_rtw_memcpy(pattrib->ra, GetAddr1Ptr(pbuf),
+					    ETH_ALEN);
+				_rtw_memcpy(pattrib->ta, get_addr2_ptr(pbuf),
+					    ETH_ALEN);
+				_rtw_memcpy(pattrib->bssid,
+					    GetAddr1Ptr(pbuf), ETH_ALEN);
+				break;
+			default:
+				_rtw_memcpy(pattrib->ra, GetAddr1Ptr(pbuf),
+					    ETH_ALEN);
+				_rtw_memcpy(pattrib->ta, get_addr2_ptr(pbuf),
+					    ETH_ALEN);
+				_rtw_memcpy(pattrib->bssid,
+					    GetAddr3Ptr(pbuf), ETH_ALEN);
+				break;
+			}
+
+			/* Parse QoS/TID if present (QoS data subtype
+			 * has BIT(7)|BIT(3) set in frame control) */
+			if ((GetFrameSubType(pbuf) & WIFI_QOS_DATA_TYPE)
+			    == WIFI_QOS_DATA_TYPE) {
+				u8 a4_shift = (to_fr_ds == 3) ?
+					      ETH_ALEN : 0;
+				pattrib->qos = 1;
+				pattrib->priority = GetPriority(
+					(pbuf + WLAN_HDR_A3_LEN + a4_shift));
+			} else {
+				pattrib->qos = 0;
+				pattrib->priority = 0;
+			}
+
+			ret = rtw_coop_rx_submit_helper_frame(
+				precvframe, primary_padapter);
+			if (ret == RTW_RX_HANDLED) {
+				goto exit;
+			}
+			/* If merge rejected, free the frame */
+			rtw_free_recvframe(precvframe,
+				&primary_padapter->recvpriv.free_recv_queue);
+			goto exit;
+		}
+		/* Non-data frames (mgmt/ctrl) from helper: drop */
+		rtw_free_recvframe(precvframe,
+			&primary_padapter->recvpriv.free_recv_queue);
+		goto exit;
+	}
 
 	if (ra_is_bmc == _FALSE) {
 		/* UC frame */

--- a/docs/cooperative_rx_design.md
+++ b/docs/cooperative_rx_design.md
@@ -1,0 +1,371 @@
+# Cooperative RX Diversity Mode — Design Document
+## RTL8821CU Vendor Driver (8821cu-20210916)
+
+### Executive Feasibility Summary
+
+**Verdict: FEASIBLE with careful implementation.**
+
+The RTL8821CU vendor driver uses a cfg80211 + custom vendor MLME stack (NOT
+mac80211). The RX path is entirely in-driver, giving us full control over
+frame processing order. Two separate identical USB adapters each have their
+own `dvobj_priv` and `_adapter` structures, but can be linked via a new
+cross-device cooperative context.
+
+The key challenge is that duplicate detection (`recv_decache`) and PN replay
+checking (`recv_ucast_pn_decache`) occur early in the RX path (inside
+`validate_recv_data_frame`), BEFORE the AMPDU reorder window. A helper
+adapter's copy of a frame would be rejected as a duplicate or replay by the
+primary's normal path. The solution is to inject helper frames into the
+primary's RX path at a point where they bypass duplicate/PN checks that
+already ran on the primary's copy, while still entering the reorder window
+correctly.
+
+**Optimal merge point:** After `recvbuf2recvframe()` parsing but BEFORE
+`validate_recv_data_frame()`, inside `recv_func_prehandle()`. The helper
+frame enters the primary adapter's `recv_indicatepkt_reorder()` directly,
+where the reorder window provides natural duplicate suppression (same
+sequence number = same slot = no double delivery).
+
+### 1. Current Driver Architecture
+
+#### 1.1 Stack Type
+- **cfg80211 + vendor MLME** (NOT mac80211)
+- Driver implements its own association state machine, AMPDU reorder,
+  crypto, defragmentation
+- Each USB device gets one `dvobj_priv` with up to CONFIG_IFACE_NUMBER
+  virtual adapters
+
+#### 1.2 RX Path (USB URB to network stack)
+
+```
+USB Hardware → usb_read_port_complete() [URB completion callback]
+    → rx_skb_queue (enqueue SKB)
+    → usb_recv_tasklet() [tasklet processing]
+    → recvbuf2recvframe() [parse RX descriptor, extract PHY status]
+        → rtl8821c_query_rx_desc() [24-byte descriptor parsing]
+        → pre_recv_entry() [interface routing, PHY status query]
+            → rtw_recv_entry() → recv_func()
+                → recv_func_prehandle()
+                    → validate_recv_frame()
+                        → validate_recv_data_frame()
+                            → recv_decache()           ← SEQ duplicate check
+                            → recv_ucast_pn_decache()   ← PN replay check
+                → recv_func_posthandle()
+                    → decryptor()                       ← SW decryption
+                    → recvframe_chk_defrag()            ← fragment reassembly
+                    → portctrl()                        ← 802.1X port control
+                    → recv_indicatepkt_reorder()        ← AMPDU reorder window
+                        → check_indicate_seq()
+                        → enqueue_reorder_recvframe()
+                        → recv_indicatepkts_in_order()
+                            → recv_process_mpdu()
+                                → wlanhdr_to_ethhdr()
+                                → rtw_recv_indicatepkt()
+                                    → netif_rx() / napi_gro_receive()
+```
+
+#### 1.3 Key Structures
+
+- `dvobj_priv`: Per-USB-device. Contains `padapters[]`, channel context,
+  hardware mutexes. Each physical USB dongle has its own dvobj.
+- `_adapter`: Per-interface. Contains `recvpriv`, `mlmepriv`, `stapriv`,
+  `securitypriv`. Has `iface_id` and `dvobj` pointer.
+- `sta_info`: Per-station. Contains `recvreorder_ctrl[16]` (per-TID reorder
+  windows), `sta_recvpriv.rxcache.tid_rxseq[16]` (duplicate detection).
+- `recv_reorder_ctrl`: Per-TID. `indicate_seq` (window start), `wsize_b`
+  (window size, typically 64), `pending_recvframe_queue`.
+- `rx_pkt_attrib`: Per-frame metadata. `seq_num`, `frag_num`, `priority`
+  (TID), `encrypt`, `bdecrypted`, `bssid[]`, `ta[]`, `ra[]`, RSSI, etc.
+
+#### 1.4 Duplicate Detection
+
+`recv_decache()` (core/rtw_recv.c:863): Compares `(seq_num << 4 | frag_num)`
+against per-STA per-TID `tid_rxseq[]`. Exact match = duplicate → drop.
+Updates cache on accept.
+
+#### 1.5 PN Replay Protection
+
+`recv_ucast_pn_decache()` (core/rtw_recv.c:800): For AES/CCMP, extracts
+48-bit PN from IV header. Checks `VALID_PN_CHK(pkt_pn, curr_pn)` which
+requires strictly increasing PN. Updates cache on accept.
+
+**Critical note:** The PN check currently has a commented-out `return _FAIL`
+line (line 820), meaning PN replay for unicast is logged but NOT enforced in
+the current codebase. This actually simplifies cooperative mode but is a
+pre-existing security concern.
+
+#### 1.6 AMPDU Reorder Window
+
+`recv_indicatepkt_reorder()` (core/rtw_recv.c:3621):
+- Window size typically 64 (`wsize_b`)
+- `check_indicate_seq()`: Drops frames with `SN_LESS(seq_num, indicate_seq)`
+- `enqueue_reorder_recvframe()`: Inserts in-order by sequence number into
+  `pending_recvframe_queue`. If slot already occupied → frame is discarded
+  (natural duplicate suppression).
+- `recv_indicatepkts_in_order()`: Delivers consecutive frames starting at
+  `indicate_seq`.
+- Timer: 50ms timeout forces delivery of buffered frames.
+
+**Key insight:** The reorder window provides natural duplicate suppression.
+If we inject a helper frame into the reorder path, and the primary already
+received that sequence number, it will already be in the queue or already
+delivered. The `enqueue_reorder_recvframe()` function inserts by sequence
+number and will find the slot occupied → discard the duplicate. This is our
+primary dedup mechanism for AMPDU traffic.
+
+#### 1.7 Hardware Decryption
+
+The RTL8821C can decrypt in hardware. `bdecrypted` flag in `rx_pkt_attrib`
+indicates whether HW already decrypted. If both adapters have the same keys
+installed, both can HW-decrypt. If helper HW-decrypts, the frame arrives
+already decrypted and can skip SW decryption on the primary path.
+
+### 2. Cooperative Mode Design
+
+#### 2.1 Architecture Overview
+
+```
+  USB Dongle A (Primary)          USB Dongle B (Helper)
+  ┌──────────────────┐            ┌──────────────────┐
+  │ dvobj_priv (A)   │            │ dvobj_priv (B)   │
+  │   adapter (A)    │            │   adapter (B)    │
+  │   normal RX path │            │   helper RX path │
+  └────────┬─────────┘            └────────┬─────────┘
+           │                               │
+           │                    ┌──────────┘
+           │                    │ cooperative_rx_submit()
+           │                    ▼
+           │         ┌─────────────────────┐
+           │         │ Cooperative Merge    │
+           │         │ - validate BSSID/TA  │
+           │         │ - check seq/TID      │
+           │         │ - inject into        │
+           │         │   primary reorder    │
+           │         └─────────┬───────────┘
+           │                   │
+           ▼                   ▼
+     ┌─────────────────────────────────┐
+     │ Primary adapter's reorder window│
+     │ (natural duplicate suppression) │
+     └─────────────┬───────────────────┘
+                   │
+                   ▼
+          Network stack (one stream)
+```
+
+#### 2.2 Merge Point Selection
+
+**Selected merge point:** Inside the primary adapter's
+`recv_indicatepkt_reorder()`, or equivalently, after
+`recv_func_posthandle()` processing but feeding into the reorder path.
+
+For the helper frame, we:
+1. Parse the RX descriptor and extract metadata (done in helper's
+   `recvbuf2recvframe()`)
+2. Validate the frame belongs to the primary's active session (BSSID, TA match)
+3. Perform decryption if needed (helper can use HW decrypt with same keys)
+4. Feed directly into primary's `recv_indicatepkt_reorder()` or
+   `recv_process_mpdu()` depending on whether it's AMPDU
+
+**Why this point:**
+- Before reorder: helper frames fill gaps in primary's reorder window
+- After decrypt: frame content is usable
+- Reorder window provides natural dedup: same seq_num → same slot → no
+  double delivery
+- For non-QoS/non-AMPDU traffic: explicit seq_num check before delivery
+
+#### 2.3 Cooperative Context Structure
+
+```c
+/* Global cooperative RX group - spans across dvobj boundaries */
+struct cooperative_rx_group {
+    spinlock_t lock;
+
+    /* Primary adapter reference */
+    _adapter *primary;
+    struct dvobj_priv *primary_dvobj;
+
+    /* Helper adapter(s) - extensible to N helpers */
+    _adapter *helpers[COOP_MAX_HELPERS];  /* initially 1 */
+    struct dvobj_priv *helper_dvobjs[COOP_MAX_HELPERS];
+    int num_helpers;
+
+    /* Session binding */
+    u8 bound_bssid[ETH_ALEN];   /* BSSID we're filtering for */
+    u8 bound_channel;
+    u8 bound_bw;
+    bool active;                 /* feature is live */
+
+    /* Statistics */
+    atomic_t helper_rx_candidates;   /* frames considered */
+    atomic_t helper_rx_accepted;     /* frames injected */
+    atomic_t helper_rx_dup_dropped;  /* duplicates caught */
+    atomic_t helper_rx_foreign;      /* wrong BSSID/TA */
+    atomic_t helper_rx_crypto_err;   /* decrypt failures */
+    atomic_t helper_rx_late;         /* too late for reorder */
+    atomic_t fallback_events;        /* helper disappeared */
+};
+```
+
+#### 2.4 Helper Frame Injection Flow
+
+```
+Helper USB URB completion
+  → usb_recv_tasklet() [helper's own tasklet]
+  → recvbuf2recvframe() [parse descriptor, get metadata]
+  → cooperative_rx_submit() [NEW - instead of normal path]
+      1. Check group->active
+      2. Validate BSSID matches group->bound_bssid
+      3. Validate TA matches expected AP MAC
+      4. Extract seq_num, TID, encrypt status
+      5. If encrypted and not HW-decrypted: attempt SW decrypt
+         using primary's security context
+      6. Acquire primary's reorder lock
+      7. For QoS/AMPDU: inject into primary's
+         recv_indicatepkt_reorder() via the per-STA
+         recvreorder_ctrl[tid]
+      8. For non-QoS: explicit seq check, then
+         recv_process_mpdu() directly
+      9. Update statistics
+```
+
+#### 2.5 Locking Model
+
+- `cooperative_rx_group.lock` (spinlock): Protects group membership changes
+  (pairing, unpairing, teardown)
+- Primary's reorder queue lock: Already exists per-STA, reused for
+  helper injection (same lock protects reorder window)
+- RCU for group pointer access: Helper's hot path reads group pointer
+  under RCU, teardown uses synchronize_rcu
+
+#### 2.6 Lifecycle
+
+```
+States: DISABLED → IDLE → BINDING → ACTIVE → TEARDOWN → DISABLED
+
+DISABLED: Module param off. No code paths touched.
+IDLE:     Module param on, no helper paired.
+BINDING:  Helper adapter detected, channel/BSSID sync in progress.
+ACTIVE:   Helper contributing frames to primary's reorder window.
+TEARDOWN: Helper unplugged or feature disabled, draining queues.
+```
+
+#### 2.7 Non-AMPDU Traffic Handling
+
+For non-QoS frames that don't go through the reorder window:
+- Maintain a small cooperative seq_num cache (last N accepted seq_nums)
+- Helper frame accepted only if its seq_num is NOT in the cache
+- This prevents duplicate delivery for non-AMPDU traffic
+
+### 3. Safety Contract (Phase 1)
+
+#### 3.1 Behavioral Contract
+
+1. When `rtw_cooperative_rx=0` (default): **ZERO code path changes**.
+   All cooperative code is behind runtime checks.
+2. Primary adapter appears as ordinary wlan interface.
+3. Helper adapter's netdev is DOWN and not independently usable while
+   slaved.
+4. Helper failure → graceful fallback to primary-only with log message.
+5. No deadlock on USB disconnect/reset/suspend of either adapter.
+6. AP/client mode compatibility preserved (first implementation: STA only).
+
+#### 3.2 Non-Goals (First Implementation)
+
+- No throughput bonding / bandwidth aggregation
+- No AP mode cooperative RX (STA only first)
+- No multi-channel operation
+- No cross-BSSID roaming assistance
+- No helper TX capability
+- No monitor mode while cooperative active
+- No automatic adapter discovery (manual pairing via sysfs/debugfs)
+
+#### 3.3 Kill Switches
+
+- Module parameter: `rtw_cooperative_rx` (0=disabled, 1=enabled, default=0)
+- Runtime sysfs: `/sys/class/net/wlanX/coop_rx/enabled` (write 0 to disable)
+- debugfs: `/sys/kernel/debug/rtw_coop_rx/` for stats and diagnostics
+- Emergency: unplug helper adapter → instant fallback
+
+### 4. Verification Gates
+
+#### Gate 0 (Build)
+- Compiles cleanly with cooperative_rx disabled
+- Compiles cleanly with cooperative_rx enabled
+- No new warnings in touched files
+
+#### Gate 1 (Single-Adapter Regression)
+With `rtw_cooperative_rx=0`:
+- Association works
+- DHCP works
+- TCP iperf sustained
+- UDP iperf works
+- AMPDU negotiates
+- Monitor mode works
+- No kernel warnings
+
+#### Gate 2 (Cooperative Idle)
+With `rtw_cooperative_rx=1` but no helper paired:
+- All Gate 1 tests pass unchanged
+- No duplicate packets
+- No throughput regression (< 2%)
+- No kernel warnings
+
+#### Gate 3 (Cooperative Active)
+With helper paired and active:
+- Single coherent RX stream to stack
+- No duplicate delivery (tcpdump verification)
+- Under primary attenuation: measurable packet rescue
+- Stats counters incrementing correctly
+- Helper unplug: clean fallback, no crash
+
+### 5. Patch Sequence Plan
+
+#### Patch 1: Infrastructure — cooperative_rx header and module param
+- New file: `include/rtw_cooperative_rx.h`
+- New file: `core/rtw_cooperative_rx.c`
+- Module param in `os_dep/linux/os_intfs.c`
+- Makefile addition
+- **Gate:** Compiles, loads, param visible, no functional change
+
+#### Patch 2: Cooperative group lifecycle
+- Group create/destroy/bind/unbind
+- sysfs interface for manual pairing
+- Helper adapter state management
+- **Gate:** Can pair/unpair adapters, no RX path changes
+
+#### Patch 3: Helper RX interception
+- Hook in helper's `pre_recv_entry()` to redirect to cooperative path
+- Frame validation (BSSID, TA, session matching)
+- **Gate:** Helper frames are intercepted and counted, not yet injected
+
+#### Patch 4: Primary reorder injection
+- Helper frames injected into primary's reorder window
+- Duplicate suppression via reorder window
+- Non-AMPDU dedup cache
+- **Gate:** Helper frames visible in primary's stats, no double delivery
+
+#### Patch 5: Statistics and debugfs
+- All counters exposed
+- Debug logging for troubleshooting
+- **Gate:** Full observability
+
+### 6. Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Double packet delivery | Medium | High | Reorder window dedup + explicit seq check |
+| Primary crash on helper unplug | Medium | Critical | RCU-protected group pointer, null checks |
+| Reorder window corruption | Low | Critical | Same lock as normal path, careful injection |
+| PN/replay confusion | Low | High | Helper frames use primary's PN state |
+| Performance regression (disabled) | Low | Medium | All checks behind `if (unlikely(coop_enabled))` |
+| Memory leak on teardown | Medium | Medium | Explicit cleanup, leak detection counters |
+| Stale state after roam | Medium | High | Unbind on disconnect/roam, rebind after |
+| Locking inversion deadlock | Low | Critical | Lock ordering: group lock → reorder lock |
+
+### 7. Rollback Strategy
+
+- Set `rtw_cooperative_rx=0` → immediate disable, zero code path impact
+- Remove helper USB adapter → automatic fallback
+- Revert patch series → all changes in isolated files + minimal hooks
+- Each patch independently revertible in reverse order

--- a/include/rtw_cooperative_rx.h
+++ b/include/rtw_cooperative_rx.h
@@ -1,0 +1,163 @@
+/******************************************************************************
+ *
+ * Copyright(c) 2024 Realtek Corporation.
+ *
+ * Cooperative RX Diversity Mode
+ *
+ * Allows a helper USB adapter (same chipset) to contribute received frames
+ * that the primary adapter missed, improving RX robustness under fading,
+ * interference, or multipath conditions.
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of version 2 of the GNU General Public License as
+ * published by the Free Software Foundation.
+ *
+ *****************************************************************************/
+#ifndef __RTW_COOPERATIVE_RX_H__
+#define __RTW_COOPERATIVE_RX_H__
+
+#include <linux/types.h>
+#include <linux/spinlock.h>
+#include <linux/atomic.h>
+#include <linux/if_ether.h>
+#include <linux/compiler.h>
+
+/* Forward declarations — full definitions come from drv_types.h */
+struct _ADAPTER;
+typedef struct _ADAPTER _adapter;
+struct dvobj_priv;
+struct net_device;
+union recv_frame;
+struct dentry;
+
+#define COOP_MAX_HELPERS		4
+#define COOP_NONQOS_SEQ_CACHE_SZ	32
+
+enum coop_rx_state {
+	COOP_STATE_DISABLED = 0,
+	COOP_STATE_IDLE,
+	COOP_STATE_BINDING,
+	COOP_STATE_ACTIVE,
+	COOP_STATE_TEARDOWN,
+};
+
+/* Statistics counters for observability */
+struct coop_rx_stats {
+	atomic_t helper_rx_candidates;	/* frames considered from helper */
+	atomic_t helper_rx_accepted;	/* frames injected into primary */
+	atomic_t helper_rx_dup_dropped;	/* duplicates caught at merge */
+	atomic_t helper_rx_foreign;	/* wrong BSSID/TA, rejected */
+	atomic_t helper_rx_crypto_err;	/* decryption failures */
+	atomic_t helper_rx_late;	/* too late for reorder window */
+	atomic_t helper_rx_no_sta;	/* sta_info not found */
+	atomic_t fallback_events;	/* helper disappeared/failed */
+	atomic_t pair_events;		/* successful pairings */
+	atomic_t unpair_events;		/* teardown events */
+};
+
+/*
+ * Non-QoS sequence number cache for duplicate detection.
+ * The AMPDU reorder window handles dedup for QoS/AMPDU traffic,
+ * but non-QoS frames need explicit tracking.
+ */
+struct coop_nonqos_seq_cache {
+	u16 seqs[COOP_NONQOS_SEQ_CACHE_SZ];
+	u8 idx;
+};
+
+/*
+ * Cooperative RX group — the central coordination object.
+ * Spans across dvobj boundaries (separate USB devices).
+ * Protected by spinlock for membership changes, RCU for hot-path reads.
+ */
+struct cooperative_rx_group {
+	spinlock_t lock;
+	enum coop_rx_state state;
+
+	/* Primary adapter — the one with active STA connection */
+	_adapter *primary;
+	struct dvobj_priv *primary_dvobj;
+
+	/* Helper adapter(s) — contribute RX frames only */
+	_adapter *helpers[COOP_MAX_HELPERS];
+	struct dvobj_priv *helper_dvobjs[COOP_MAX_HELPERS];
+	int num_helpers;
+
+	/* Session binding — which BSS we're filtering for */
+	u8 bound_bssid[ETH_ALEN];
+	u8 bound_ap_mac[ETH_ALEN];	/* TA of the AP */
+	u8 bound_channel;
+	u8 bound_bw;
+
+	/* Non-QoS dedup cache */
+	struct coop_nonqos_seq_cache nonqos_cache;
+
+	/* Statistics */
+	struct coop_rx_stats stats;
+
+	/* Debugfs directory */
+	struct dentry *debugfs_dir;
+};
+
+/* Global singleton — one cooperative group for the system */
+extern struct cooperative_rx_group *rtw_coop_rx_group;
+extern int rtw_cooperative_rx;	/* module parameter */
+
+/* Lifecycle */
+int rtw_coop_rx_init(void);
+void rtw_coop_rx_deinit(void);
+
+/* Pairing */
+int rtw_coop_rx_set_primary(_adapter *adapter);
+int rtw_coop_rx_add_helper(_adapter *adapter);
+int rtw_coop_rx_remove_helper(_adapter *adapter);
+void rtw_coop_rx_remove_adapter(_adapter *adapter);
+int rtw_coop_rx_bind_session(_adapter *primary);
+void rtw_coop_rx_unbind_session(void);
+
+/* Helper RX hot path */
+int rtw_coop_rx_submit_helper_frame(union recv_frame *precvframe,
+				    _adapter *helper_adapter);
+
+/* Query helpers — these are called from hot paths so must be fast */
+static inline bool rtw_coop_rx_enabled(void)
+{
+	return READ_ONCE(rtw_cooperative_rx) != 0;
+}
+
+static inline bool rtw_coop_rx_active(void)
+{
+	struct cooperative_rx_group *grp;
+
+	if (!rtw_coop_rx_enabled())
+		return false;
+	grp = READ_ONCE(rtw_coop_rx_group);
+	return grp && READ_ONCE(grp->state) == COOP_STATE_ACTIVE;
+}
+
+static inline bool rtw_coop_rx_is_helper(_adapter *adapter)
+{
+	struct cooperative_rx_group *grp;
+	int i;
+
+	if (!rtw_coop_rx_enabled())
+		return false;
+	grp = READ_ONCE(rtw_coop_rx_group);
+	if (!grp || READ_ONCE(grp->state) < COOP_STATE_BINDING)
+		return false;
+	for (i = 0; i < READ_ONCE(grp->num_helpers); i++) {
+		if (READ_ONCE(grp->helpers[i]) == adapter)
+			return true;
+	}
+	return false;
+}
+
+/* sysfs / proc interface */
+int rtw_coop_rx_sysfs_init(struct net_device *ndev);
+void rtw_coop_rx_sysfs_deinit(struct net_device *ndev);
+
+/* debugfs */
+int rtw_coop_rx_debugfs_init(void);
+void rtw_coop_rx_debugfs_deinit(void);
+
+#endif /* __RTW_COOPERATIVE_RX_H__ */

--- a/include/rtw_recv.h
+++ b/include/rtw_recv.h
@@ -868,4 +868,8 @@ u8 adapter_allow_bmc_data_rx(_adapter *adapter);
 s32 pre_recv_entry(union recv_frame *precvframe, u8 *pphy_status);
 void count_rx_stats(_adapter *padapter, union recv_frame *prframe, struct sta_info *sta);
 
+/* Exposed for cooperative RX merge path */
+int recv_indicatepkt_reorder(_adapter *padapter, union recv_frame *prframe);
+int recv_process_mpdu(_adapter *padapter, union recv_frame *prframe);
+
 #endif

--- a/os_dep/linux/os_intfs.c
+++ b/os_dep/linux/os_intfs.c
@@ -16,6 +16,7 @@
 
 #include <drv_types.h>
 #include <hal_data.h>
+#include <rtw_cooperative_rx.h>
 
 #if (LINUX_VERSION_CODE >= KERNEL_VERSION(6, 8, 0))
 #define strlcpy strscpy
@@ -164,6 +165,11 @@ module_param(rtw_usb_rxagg_mode, int, 0644);
 
 int rtw_dynamic_agg_enable = 1;
 module_param(rtw_dynamic_agg_enable, int, 0644);
+
+/* Cooperative RX diversity: 0=disabled (default), 1=enabled */
+extern int rtw_cooperative_rx;
+module_param(rtw_cooperative_rx, int, 0644);
+MODULE_PARM_DESC(rtw_cooperative_rx, "Enable cooperative RX diversity with helper adapters (0=off, 1=on)");
 
 /* set log level when inserting driver module, default log level is _DRV_INFO_ = 4,
 * please refer to "How_to_set_driver_debug_log_level.doc" to set the available level.
@@ -2185,9 +2191,10 @@ int rtw_os_ndev_register(_adapter *adapter, const char *name)
 	else
 		ret = (register_netdevice(ndev) == 0) ? _SUCCESS : _FAIL;
 
-	if (ret == _SUCCESS)
+	if (ret == _SUCCESS) {
 		adapter->registered = 1;
-	else
+		rtw_coop_rx_sysfs_init(ndev);
+	} else
 		RTW_INFO(FUNC_NDEV_FMT" if%d Failed!\n", FUNC_NDEV_ARG(ndev), (adapter->iface_id + 1));
 
 #if defined(CONFIG_IOCTL_CFG80211)
@@ -2228,6 +2235,8 @@ void rtw_os_ndev_unregister(_adapter *adapter)
 	if ((adapter->DriverState != DRIVER_DISAPPEAR) && netdev) {
 		struct dvobj_priv *dvobj = adapter_to_dvobj(adapter);
 		u8 rtnl_lock_needed = rtw_rtnl_lock_needed(dvobj);
+
+		rtw_coop_rx_sysfs_deinit(netdev);
 
 		if (rtnl_lock_needed)
 			unregister_netdev(netdev);

--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -16,6 +16,7 @@
 
 #include <drv_types.h>
 #include <hal_data.h>
+#include <rtw_cooperative_rx.h>
 
 #include <platform_ops.h>
 
@@ -1359,6 +1360,10 @@ static void rtw_dev_remove(struct usb_interface *pusb_intf)
 
 	RTW_INFO("+rtw_dev_remove\n");
 
+	/* Remove adapter from cooperative RX group before teardown */
+	if (padapter)
+		rtw_coop_rx_remove_adapter(padapter);
+
 	dvobj->processing_dev_remove = _TRUE;
 
 	/* TODO: use rtw_os_ndevs_deinit instead at the first stage of driver's dev deinit function */
@@ -1446,6 +1451,8 @@ static int __init rtw_drv_entry(void)
 	rtw_ndev_notifier_register();
 	rtw_inetaddr_notifier_register();
 
+	rtw_coop_rx_init();
+
 	ret = usb_register(&usb_drv.usbdrv);
 
 	if (ret != 0) {
@@ -1484,6 +1491,8 @@ static void __exit rtw_drv_halt(void)
 #endif
 	rtw_ndev_notifier_unregister();
 	rtw_inetaddr_notifier_unregister();
+
+	rtw_coop_rx_deinit();
 
 	RTW_PRINT("module exit success\n");
 


### PR DESCRIPTION
## Summary

Implements cooperative RX diversity mode for the RTL8821CU driver, enabling a helper USB adapter to contribute received frames to a primary adapter's RX path, improving robustness under fading and interference conditions.

## Key Changes

- **New cooperative RX core module** (`core/rtw_cooperative_rx.c`): 
  - Implements frame validation and injection into primary adapter's AMPDU reorder window
  - Provides lifecycle management (init/deinit) for cooperative group
  - Handles adapter pairing/unpairing with primary-helper relationship
  - Includes session binding to track active BSS context
  - Maintains non-QoS duplicate detection cache for frames outside AMPDU
  - Exposes sysfs interface for runtime control (`coop_rx_enabled`, `coop_rx_role`, `coop_rx_stats`, `coop_rx_pair`, `coop_rx_unpair`, `coop_rx_bind`)
  - Provides debugfs statistics interface for observability

- **New header** (`include/rtw_cooperative_rx.h`):
  - Defines cooperative RX group structure spanning across USB device boundaries
  - Declares public API for lifecycle, pairing, and frame submission
  - Includes inline query helpers for fast hot-path checks

- **RX path integration** (`core/rtw_recv.c`):
  - Adds helper adapter detection in `pre_recv_entry()` to redirect data frames to cooperative merge path
  - Exposes `recv_process_mpdu()` and `recv_indicatepkt_reorder()` for cooperative frame injection
  - Helper frames bypass normal duplicate/PN checks and inject directly into primary's reorder window, which provides natural duplicate suppression

- **Driver initialization** (`os_dep/linux/os_intfs.c`, `os_dep/linux/usb_intf.c`):
  - Adds module parameter `rtw_cooperative_rx` (default 0, disabled)
  - Integrates cooperative RX init/deinit into driver lifecycle
  - Removes adapters from cooperative group on USB disconnect

- **sysfs integration**:
  - Registers cooperative RX attribute group per network device
  - Allows runtime pairing/unpairing of helper adapters
  - Exposes statistics and role information

- **Minor fixes**:
  - Increases radiotap header buffer size in monitor mode (64→256 bytes)
  - Exports recv functions for cooperative path use

## Implementation Details

- **Merge point**: Helper frames are injected after parsing but before duplicate/PN checks, entering the primary's reorder window directly
- **Duplicate suppression**: AMPDU reorder window provides natural dedup (same sequence number = same slot = discarded); non-QoS traffic uses explicit sequence cache
- **Locking**: Spinlock protects group membership changes; RCU used for hot-path group pointer access
- **State machine**: DISABLED → IDLE → BINDING → ACTIVE → TEARDOWN
- **Safety**: Feature is disabled by default; zero code path changes when disabled
- **Crypto**: Relies on hardware decryption with same keys on both adapters; SW decryption skipped for helper frames

https://claude.ai/code/session_0116Rjay9m5wieut4rXXNMCN