### PR TITLE
add USB ID for Mercusys MU6H v1.30

### DIFF
--- a/os_dep/linux/usb_intf.c
+++ b/os_dep/linux/usb_intf.c
@@ -272,6 +272,7 @@ static struct usb_device_id rtw_usb_id_tbl[] = {
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_EDIMAX, 0xC811, 0xff, 0xff, 0xff), .driver_info = RTL8821C}, /* 8811CU Edimax */
 	{USB_DEVICE_AND_INTERFACE_INFO(USB_VENDER_ID_EDIMAX, 0xD811, 0xff, 0xff, 0xff), .driver_info = RTL8821C}, /* 8811CU Edimax */
 	{USB_DEVICE_AND_INTERFACE_INFO(0x2001, 0x331d, 0xff, 0xff, 0xff), .driver_info = RTL8821C}, /* D-Link - DWA-171C */
+	{USB_DEVICE_AND_INTERFACE_INFO(0x2c4e, 0x0105, 0xff, 0xff, 0xff), .driver_info = RTL8821C}, /* Mercusys MU6H v1.30 */
 #endif
 
 #ifdef CONFIG_RTL8710B


### PR DESCRIPTION
## Change



Added the following device entry to `os_dep/linux/usb_intf.c`:



```c

{USB_DEVICE_AND_INTERFACE_INFO(0x2c4e, 0x0105, 0xff, 0xff, 0xff), .driver_info = RTL8821C}, /* Mercusys MU6H v1.30 */

```



## Device Information



* Product: Mercusys MU6H v1.30

* USB ID: `2c4e:0105`

* Chipset: Realtek RTL8821CU



## Test Environment



* Ubuntu 24.04 LTS

* Architecture: x86_64

* Linux kernel: 6.18

* Installation method: DKMS



## Test Results



* Driver builds successfully

* Driver installs successfully

* USB adapter is detected

* The `8821cu` module binds to the adapter

* Wi-Fi scanning works correctly

* Wi-Fi connection works correctly