### PR TITLE
Fix build failure on old kernels

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2577,5 +2577,5 @@ clean:
 endif
 
 # For compatibility with kernels prior to 2.6.24.
-EXTRA_CFLAGS += $(ccflags-y)
-EXTRA_LDFLAGS += $(ldflags-y)
+EXTRA_CFLAGS := $(ccflags-y)
+EXTRA_LDFLAGS := $(ldflags-y)


### PR DESCRIPTION
@morrownr

This fixes a build failure reported in February that has been sitting since. On Ubuntu 18.04 the driver will not build at all. Make stops partway through complaining that one of its variables refers to itself, and no module comes out.

The cause is the last two lines of the Makefile. They are there for compatibility with kernels older than 2.6.24, and they copy one set of build flags into another. Old kernels copy back the other way, so between them there is a circle. Kernels from 6.15 on stopped copying, which is why nothing recent runs into it.

The fix has those two lines work their value out on the spot, instead of leaving something behind for make to chase. I built the driver before and after against 7.0. Every file compiled with the same options and the module came out identical byte for byte.

None of your other six Realtek repos carry those lines, so this is the only one that needs it.

https://github.com/morrownr/8821cu-20210916/issues/199
